### PR TITLE
Bugfixes and features related to video production

### DIFF
--- a/demo/demo_3d_collider.py
+++ b/demo/demo_3d_collider.py
@@ -10,7 +10,7 @@ if write_to_disk:
     os.makedirs('outputs', exist_ok=True)
 
 # Try to run on GPU
-ti.init(arch=ti.cuda, device_memory_GB=2.0, use_unified_memory=False)
+ti.init(arch=ti.cuda, device_memory_GB=4.0, use_unified_memory=False)
 
 gui = ti.GUI("Taichi Elements", res=512, background_color=0x112F41)
 

--- a/download_ply.py
+++ b/download_ply.py
@@ -8,4 +8,4 @@ urls = ["bunny_low.ply", "quantized.ply", "simulation.ply", "taichi.ply", "suzan
 for url in urls:
     print(f"Downloading {url}...")
     urllib.request.urlretrieve(root_url + url, url)
-print("Download finished !")
+print("Download finished!")

--- a/engine/mpm_solver.py
+++ b/engine/mpm_solver.py
@@ -168,8 +168,7 @@ class MPMSolver:
                                                                  offset=offset)
 
             block_component(grid_m)
-            for v in grid_v.entries:
-                block_component(v)
+            block_component(grid_v)
 
             self.pid.append(pid)
             # TODO ? why
@@ -321,9 +320,9 @@ class MPMSolver:
         ti.block_dim(256)
         ti.no_activate(self.particle)
         if ti.static(self.use_bls):
-            ti.block_local(*grid_v_in.entries)
+            ti.block_local(grid_v_in)
             ti.block_local(grid_m_out)
-            ti.block_local(*grid_v_out.entries)
+            ti.block_local(grid_v_out)
         for I in ti.grouped(pid):
             p = pid[I]
             # G2P
@@ -447,7 +446,7 @@ class MPMSolver:
         ti.no_activate(self.particle)
         ti.block_dim(256)
         if ti.static(self.use_bls):
-            ti.block_local(*self.grid_v.entries)
+            ti.block_local(self.grid_v)
             ti.block_local(self.grid_m)
         for I in ti.grouped(self.pid):
             p = self.pid[I]
@@ -643,7 +642,7 @@ class MPMSolver:
     def g2p(self, dt: ti.f32):
         ti.block_dim(256)
         if ti.static(self.use_bls):
-            ti.block_local(*self.grid_v.entries)
+            ti.block_local(self.grid_v)
         ti.no_activate(self.particle)
         for I in ti.grouped(self.pid):
             p = self.pid[I]

--- a/engine/mpm_solver.py
+++ b/engine/mpm_solver.py
@@ -43,7 +43,7 @@ class MPMSolver:
         'SEPARATE': surface_separate
     }
 
-    grid_size = 4096
+    grid_size = 6144
 
     def __init__(
             self,
@@ -135,7 +135,7 @@ class MPMSolver:
         else:
             indices = ti.ijk
 
-        offset = tuple((res[i] - self.grid_size) // 2 for i in range(self.dim))
+        offset = tuple(-self.grid_size // 2 for _ in range(self.dim))
         self.offset = offset
 
         self.num_grids = 2 if self.use_g2p2g else 1
@@ -170,7 +170,8 @@ class MPMSolver:
                                                                  offset=offset)
 
             block_component(grid_m)
-            block_component(grid_v)
+            for e in grid_v.get_field_members():
+                block_component(e)
 
             self.pid.append(pid)
             # TODO ? why

--- a/engine/mpm_solver.py
+++ b/engine/mpm_solver.py
@@ -323,9 +323,10 @@ class MPMSolver:
         ti.block_dim(256)
         ti.no_activate(self.particle)
         if ti.static(self.use_bls):
-            ti.block_local(grid_v_in)
             ti.block_local(grid_m_out)
-            ti.block_local(grid_v_out)
+            for i in range(self.dim):
+                ti.block_local(grid_v_in.get_scalar_field(i))
+                ti.block_local(grid_v_out.get_scalar_field(i))
         for I in ti.grouped(pid):
             p = pid[I]
             # G2P
@@ -449,7 +450,8 @@ class MPMSolver:
         ti.no_activate(self.particle)
         ti.block_dim(256)
         if ti.static(self.use_bls):
-            ti.block_local(self.grid_v)
+            for i in range(self.dim):
+                ti.block_local(self.grid_v.get_scalar_field(i))
             ti.block_local(self.grid_m)
         for I in ti.grouped(self.pid):
             p = self.pid[I]
@@ -645,7 +647,8 @@ class MPMSolver:
     def g2p(self, dt: ti.f32):
         ti.block_dim(256)
         if ti.static(self.use_bls):
-            ti.block_local(self.grid_v)
+            for i in range(self.dim):
+                ti.block_local(self.grid_v.get_scalar_field(i))
         ti.no_activate(self.particle)
         for I in ti.grouped(self.pid):
             p = self.pid[I]

--- a/engine/mpm_solver.py
+++ b/engine/mpm_solver.py
@@ -43,8 +43,6 @@ class MPMSolver:
         'SEPARATE': surface_separate
     }
 
-    grid_size = 4096
-
     def __init__(
             self,
             res,
@@ -68,6 +66,8 @@ class MPMSolver:
         self.use_bls = use_bls
         self.g2p2g_allowed_cfl = g2p2g_allowed_cfl
         self.water_density = water_density
+        self.grid_size = 4096
+
         assert self.dim in (
             2, 3), "MPM solver supports only 2D and 3D simulations."
 
@@ -139,7 +139,7 @@ class MPMSolver:
             # The maximum grid size must be larger than twice of 
             # simulation resolution in an unbounded simulation,
             # Otherwise the top and right sides will be bounded by grid size
-            while self.grid_size <= 2 * self.res:
+            while self.grid_size <= 2 * max(self.res):
                 self.grid_size *= 2 # keep it power of two
         offset = tuple(-self.grid_size // 2 for _ in range(self.dim))
         self.offset = offset

--- a/engine/mpm_solver.py
+++ b/engine/mpm_solver.py
@@ -170,8 +170,8 @@ class MPMSolver:
                                                                  offset=offset)
 
             block_component(grid_m)
-            for e in grid_v.get_field_members():
-                block_component(e)
+            for i in range(self.dim):
+                block_component(grid_v.get_scalar_field(i))
 
             self.pid.append(pid)
             # TODO ? why

--- a/engine/particle_io.py
+++ b/engine/particle_io.py
@@ -10,7 +10,7 @@ class ParticleIO:
     x_bits = 32 - v_bits
 
     @staticmethod
-    def write_particles(solver, fn):
+    def write_particles(solver, fn, slice_size=1000000):
         t = time.time()
         output_fn = fn
 
@@ -21,7 +21,6 @@ class ParticleIO:
         ranges = np.ndarray((2, solver.dim, 2), dtype=np.float32)
 
         # Fetch data slice after slice since we don't have the GPU memory to fetch them channel after channel...
-        slice_size = 1000000
         num_slices = (n_particles + slice_size - 1) // slice_size
 
         for d in range(solver.dim):

--- a/engine/particle_io.py
+++ b/engine/particle_io.py
@@ -34,8 +34,8 @@ class ParticleIO:
             for s in range(num_slices):
                 begin = slice_size * s
                 end = min(slice_size * (s + 1), n_particles)
-                solver.copy_ranged(np_x_slice, solver.x(d), begin, end)
-                solver.copy_ranged(np_v_slice, solver.v(d), begin, end)
+                solver.copy_ranged(np_x_slice, solver.x.get_scalar_field(d), begin, end)
+                solver.copy_ranged(np_v_slice, solver.x.get_scalar_field(d), begin, end)
 
                 np_x[begin:end] = np_x_slice[:end - begin]
                 np_v[begin:end] = np_v_slice[:end - begin]
@@ -76,6 +76,14 @@ class ParticleIO:
 
     @staticmethod
     def read_particles_3d(fn):
+        return ParticleIO.read_particles(fn, 3)
+
+    @staticmethod
+    def read_particles_2d(fn):
+        return ParticleIO.read_particles(fn, 2)
+
+    @staticmethod
+    def read_particles(fn, dim):
         data = np.load(fn)
         ranges = data['ranges']
         color = data['color']
@@ -84,13 +92,13 @@ class ParticleIO:
         gc.collect()
         x = (x_and_v >> ParticleIO.v_bits).astype(np.float32) / (
             (2**ParticleIO.x_bits - 1))
-        for c in range(3):
+        for c in range(dim):
             x[:,
               c] = x[:, c] * (ranges[0, c, 1] - ranges[0, c, 0]) + ranges[0, c,
                                                                           0]
         v = (x_and_v & (2**ParticleIO.v_bits - 1)).astype(
             np.float32) / (2**ParticleIO.v_bits - 1)
-        for c in range(3):
+        for c in range(dim):
             v[:,
               c] = v[:, c] * (ranges[1, c, 1] - ranges[1, c, 0]) + ranges[1, c,
                                                                           0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+taichi==0.7.31
+plyfile


### PR DESCRIPTION
- SNode placement in MPM Solver is made compatible with the refactored Taichi Field API (>=0.7.30)
- Adds methods to emit regular polygons
- Allows for reading 2D particle information
- Allows for changing copying chunk size when writing particle information
- Makes the texture resolution in `add_texture_2d` consistent with MPM grid resolution
- Centers the simulation domain when `unbounded=True`
- Adds a "stationary material" with zero velocity