### PR TITLE
Fix trailing slash removal logic

### DIFF
--- a/utils/install_blender_addon.py
+++ b/utils/install_blender_addon.py
@@ -8,7 +8,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument('-k', action='store_true', help='keep refreshing')
 
 addon_path = os.environ['BLENDER_USER_ADDON_PATH']
-if addon_path[:-1] == '/':
+if addon_path[-1] == '/':
     addon_path = addon_path[:-1]
 assert addon_path.endswith(os.path.join('scripts', 'addons'))
 


### PR DESCRIPTION
This is probably to check if the last character is `/` and remove if it is, but a `:` was added which makes the script unable to run if the environment variable has trailing `/`;
Pretty tiny fix but I guess there's gonna be more elegant way.